### PR TITLE
upgrades to babel6

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,7 @@
+{
+  "presets": [
+    "es2015",
+    "stage-2",
+    "react"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -16,8 +16,13 @@
     "react-dom": "^15.0"
   },
   "devDependencies": {
-    "babel-core": "^5.8.33",
-    "babel-loader": "^5.3.3",
+    "babel-cli": "^6.16.0",
+    "babel-core": "^6.17.0",
+    "babel-loader": "^6.2.5",
+    "babel-polyfill": "^6.16.0",
+    "babel-preset-es2015": "^6.16.0",
+    "babel-preset-react": "^6.16.0",
+    "babel-preset-stage-2": "^6.17.0",
     "css-loader": "^0.22.0",
     "react-hot-loader": "^1.3.0",
     "style-loader": "^0.13.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -5,6 +5,7 @@ const webpack = require('webpack');
 const config = {
 
 	entry: [
+		'babel-polyfill',
 	    'webpack-dev-server/client?http://localhost:3443',
         'webpack/hot/dev-server',
 		path.join( __dirname, 'src/Router.jsx')
@@ -16,13 +17,8 @@ const config = {
 	},
 	module: {
 		loaders: [
-			{
-				test: /\.js|jsx$/, loaders: ['react-hot', 'babel'],
-				exclude: /node_modules/
-			},
-			{
-				test: /\.css$/, loaders: ['style', 'css']
-			}
+			{ test: /\.js|jsx$/, exclude: /node_modules/, loaders: ['react-hot', 'babel'] },
+			{ test: /\.css$/, loaders: ['style', 'css'] }
 		]
 	},
 	plugins: [


### PR DESCRIPTION
Misc Learnings
- `babel-core` , `babel-loader` are the main modules
- `babel-loader`, `babel` refers to the same module
- Every transform has to be configured inside the `.babelrc` via `plugin`
- To get started use the `preset` which are an array of `plugins`. Most common ones are `react, stage-2, es2015`
- `babel-polyfil` allows to use features of ES6 which are not covered in the `babel-core`
- `babel-register` transpiles use to use ES6 modules in node. [Do not need it now.]
